### PR TITLE
中間点のあるオブジェクトに対する修正．

### DIFF
--- a/exin.hpp
+++ b/exin.hpp
@@ -413,9 +413,14 @@ namespace my
 		// 戻り値
 		// 拡張データへのオフセットです。
 		//
-		static DWORD get_exdata_offset(ExEdit::Object* object, int32_t filter_index)
+		DWORD get_exdata_offset(ExEdit::Object* object, int32_t filter_index)
 		{
-			return object->exdata_offset + object->filter_param[filter_index].exdata_offset;
+			// 中間点の先頭オブジェクトを取得します．
+			auto* leader = object;
+			if (object->index_midpt_leader >= 0)
+				leader = *address.variable.object_table + object->index_midpt_leader;
+
+			return leader->exdata_offset + leader->filter_param[filter_index].exdata_offset;
 		}
 
 		//

--- a/main.cpp
+++ b/main.cpp
@@ -235,13 +235,17 @@ namespace call_func_proc
 	//
 	ExEdit::Filter* find_inheritance_filter(ExEdit::Object* object)
 	{
+		// 中間点の先頭オブジェクトを取得します．
+		auto* leader = object;
+		if (object->index_midpt_leader >= 0) leader = exin.get_object(object->index_midpt_leader);
+
 		for (int32_t i = 0; i < ExEdit::Object::MAX_FILTER; i++)
 		{
 			auto filter = exin.get_filter(object, i);
 			if (!filter) return nullptr;
 			if (!filter->name) continue;
 			if (strcmp(filter->name, plugin_name)) continue;
-			if (!(object->filter_status[i] & ExEdit::Object::FilterStatus::Active)) continue;
+			if (!(leader->filter_status[i] & ExEdit::Object::FilterStatus::Active)) continue;
 
 			return filter;
 		}


### PR DESCRIPTION
中間点のあるオブジェクトに対してはうまく動かない場面がありました．

1. 継承先のオブジェクトに中間点がある場合，その中間点以降は継承元オブジェクトのテキストが表示された．
2. 継承元のオブジェクトに中間点がある場合，その中間点以降はそもそも継承元オブジェクトとして機能しなかった．

(1) はテキストオブジェクトの `exdata` を取得する際，そのオブジェクトが中間点の先頭オブジェクトであることを確認していなかったのが原因でした．exin.hpp で `exdata` のオフセットアドレスを取得する関数を修正しました．

(2) は「継承元」フィルタ効果を探す際，それが有効であるかどうかの確認に中間点の先頭オブジェクトを取り直すことで修正しました．

以上ご確認いただければと思います．